### PR TITLE
Add dependabot to manage npm dependencies.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+---
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
By adding a configuration file for dependabot we can avoid having to manually bump dependencies.

Once a week dependabot will raise pull requests for us to automatically bump dependencies.

Refer: https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide