### PR TITLE
Reduce dependabot frequency to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,9 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly


### PR DESCRIPTION
With the hackathon now concluded lets reduce the dependabot frequency to `monthly` so we can reduce maintenance overhead but still keep this repository secure and healthy 🧑‍🔧 